### PR TITLE
Update boot_merger.c

### DIFF
--- a/tools/rockchip/boot_merger.c
+++ b/tools/rockchip/boot_merger.c
@@ -930,7 +930,7 @@ static bool unpackBoot(char *path)
 	bool ret = false;
 	FILE *inFile = fopen(path, "rb");
 	int entryNum, i;
-	char name[MAX_NAME_LEN];
+	char name[MAX_NAME_LEN+1];
 	rk_boot_entry *entrys;
 	if (!inFile) {
 		fprintf(stderr, "loader(%s) not found\n", path);


### PR DESCRIPTION
Fix Array Out of bounds :: MAX_NAME_LEN =20 and  char name[MAX_NAME_LEN] of function "unpackBoot" ,but str[len]=0  in function "wide2str" equals str[20]=0;